### PR TITLE
Add user-supplied config file to gitignore

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# slushy development 0.5.2.9001
+- Add user-supplied configuration file to be in the `gitignore` file
+- Configuration file is passed to `additional_unignore_files` in `update_ignores()` and appended to list of files to unignore
+- Add tests for `get_config()` and `update_ignores()`
+
 # slushy development 0.5.2.9000
 - Add a `keep` parameter to the `slushy_remove()` function, allowing users to specify files that should not be removed during the cleanup process. The default value is `"slushy_config.yml"`.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,5 @@
 # slushy development 0.5.2.9001
-- Add user-supplied configuration file to be in the `gitignore` file
-- Configuration file is passed to `additional_unignore_files` in `update_ignores()` and appended to list of files to unignore
-- Add tests for `get_config()` and `update_ignores()`
+- Add user-supplied configuration file to be 'unignored' in the `gitignore` file
 
 # slushy development 0.5.2.9000
 - Add a `keep` parameter to the `slushy_remove()` function, allowing users to specify files that should not be removed during the cleanup process. The default value is `"slushy_config.yml"`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,6 @@
 # slushy development version
 - Add user-supplied configuration file to be 'unignored' in the `gitignore` file
 
-# slushy development 0.5.2.9000
 - Add a `keep` parameter to the `slushy_remove()` function, allowing users to specify files that should not be removed during the cleanup process. The default value is `"slushy_config.yml"`.
 
 # slushy 0.5.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# slushy development 0.5.2.9001
+# slushy development version
 - Add user-supplied configuration file to be 'unignored' in the `gitignore` file
 
 # slushy development 0.5.2.9000

--- a/R/config.R
+++ b/R/config.R
@@ -21,7 +21,6 @@ get_config <- function(config_file = "slushy_config.yml"){
                  config_file_name = config_file)
   
   # return the configuration list with the attached attribute
-  return(config_list)
 }
 
 #' Create a new slushy_config.yml from template in project directory

--- a/R/config.R
+++ b/R/config.R
@@ -20,7 +20,6 @@ get_config <- function(config_file = "slushy_config.yml"){
   structure(config_list,
                  config_file_name = config_file)
   
-  # return the configuration list with the attached attribute
 }
 
 #' Create a new slushy_config.yml from template in project directory

--- a/R/config.R
+++ b/R/config.R
@@ -14,7 +14,7 @@ get_config <- function(config_file = "slushy_config.yml"){
   # get name of default config
   config <- get(value = "config_name", config = "default", file = config_file)
 
-  config_list <- config::get(value = config, config = "default", file = config_file)
+  config_list <- get(value = config, config = "default", file = config_file)
   
   # attach the file name as an attribute
   attr(config_list, "config_file_name") <- config_file

--- a/R/config.R
+++ b/R/config.R
@@ -12,7 +12,7 @@ get_config <- function(config_file = "slushy_config.yml"){
   }
 
   # get name of default config
-  config <- config::get(value = "config_name", config = "default", file = config_file)
+  config <- get(value = "config_name", config = "default", file = config_file)
 
   config_list <- config::get(value = config, config = "default", file = config_file)
   

--- a/R/config.R
+++ b/R/config.R
@@ -14,8 +14,13 @@ get_config <- function(config_file = "slushy_config.yml"){
   # get name of default config
   config <- config::get(value = "config_name", config = "default", file = config_file)
 
-  config::get(value = config, config = "default", file = config_file)
-
+  config_list <- config::get(value = config, config = "default", file = config_file)
+  
+  # attach the file name as an attribute
+  attr(config_list, "config_file_name") <- config_file
+  
+  # return the configuration list with the attached attribute
+  return(config_list)
 }
 
 #' Create a new slushy_config.yml from template in project directory

--- a/R/config.R
+++ b/R/config.R
@@ -17,7 +17,8 @@ get_config <- function(config_file = "slushy_config.yml"){
   config_list <- get(value = config, config = "default", file = config_file)
   
   # attach the file name as an attribute
-  attr(config_list, "config_file_name") <- config_file
+  structure(config_list,
+                 config_file_name = config_file)
   
   # return the configuration list with the attached attribute
   return(config_list)

--- a/R/inits.R
+++ b/R/inits.R
@@ -160,11 +160,18 @@ add_slushy_rprofile_code <- function(project = proj_root(),
 #' - R packages being used in the project are not accidentally overlooked
 #' - Custom configuration files (if provided) are added to the list of files that should not be ignored.
 #' 
-#' @param project location of project
-#' @param additional_unignore_files A character vector of additional file names to be unignored (i.e., prepended with an exclamation mark in .gitignore). Defaults to NULL.
+#' @param project Location of project
+#' @param additional_unignore_files A character vector of additional file names to be unignored. Defaults to NULL.
 #' 
 #' @noRd
 update_ignores <- function(project = proj_root(), additional_unignore_files = NULL){
+  
+  # Prepend '!' to all additional_unignore_files
+  unignore_files <- if (!is.null(additional_unignore_files)) {
+    paste0("!", additional_unignore_files)
+  } else {
+    NULL
+  }
   
   # add slushy files to gitignore
   git_ignore_file <- file.path(project, ".gitignore")
@@ -173,11 +180,9 @@ update_ignores <- function(project = proj_root(), additional_unignore_files = NU
                   "!.renvignore",
                   "!renv",
                   "!renv.lock",
-                  "!*.Rproj")
+                  "!*.Rproj",
+                  unignore_files)
   
-  if (!is.null(additional_unignore_files)) {
-    renv_files <- c(renv_files, additional_unignore_files)
-  }
   
   if (file.exists(git_ignore_file)){
     git_ignore <- readLines(git_ignore_file, warn = FALSE)

--- a/R/inits.R
+++ b/R/inits.R
@@ -158,11 +158,13 @@ add_slushy_rprofile_code <- function(project = proj_root(),
 #' Makes modifications to the .gitignore and .renvignore files to ensure the following:
 #' - critical files related to slushy are not accidentally ignored by git
 #' - R packages being used in the project are not accidentally overlooked
+#' - Custom configuration files (if provided) are added to the list of files that should not be ignored.
 #' 
 #' @param project location of project
+#' @param additional_unignore_files A character vector of additional file names to be unignored (i.e., prepended with an exclamation mark in .gitignore). Defaults to NULL.
 #' 
 #' @noRd
-update_ignores <- function(project = proj_root()){
+update_ignores <- function(project = proj_root(), additional_unignore_files = NULL){
   
   # add slushy files to gitignore
   git_ignore_file <- file.path(project, ".gitignore")
@@ -172,6 +174,10 @@ update_ignores <- function(project = proj_root()){
                   "!renv",
                   "!renv.lock",
                   "!*.Rproj")
+  
+  if (!is.null(additional_unignore_files)) {
+    renv_files <- c(renv_files, additional_unignore_files)
+  }
   
   if (file.exists(git_ignore_file)){
     git_ignore <- readLines(git_ignore_file, warn = FALSE)

--- a/R/slushy_init.R
+++ b/R/slushy_init.R
@@ -75,8 +75,20 @@ slushy_init <- function(date = NULL,
                  remove_empty = TRUE)
   
   # Update ignores -------------------------------------------------------------
-  update_ignores(project = project)
-
+  
+  # Extract config file name from config list attributes
+  config_file_name <- attr(config, "config_file_name")
+  
+  # Prepend an exclamation mark to the config file name to unignore it
+  if (!is.null(config_file_name)) {
+    config_file_unignore <- paste0("!", config_file_name)
+  } else {
+    config_file_unignore <- NULL
+  }
+  
+  # Update ignores, including the config file
+  update_ignores(project = project, additional_unignore_files = config_file_unignore)
+  
   # Initialize new renv project w/ snapshot date -------------------------------
   config_date <- config$date
   date <- date %||% config_date 

--- a/R/slushy_init.R
+++ b/R/slushy_init.R
@@ -75,19 +75,8 @@ slushy_init <- function(date = NULL,
                  remove_empty = TRUE)
   
   # Update ignores -------------------------------------------------------------
-  
-  # Extract config file name from config list attributes
   config_file_name <- attr(config, "config_file_name")
-  
-  # Prepend an exclamation mark to the config file name to unignore it
-  if (!is.null(config_file_name)) {
-    config_file_unignore <- paste0("!", config_file_name)
-  } else {
-    config_file_unignore <- NULL
-  }
-  
-  # Update ignores, including the config file
-  update_ignores(project = project, additional_unignore_files = config_file_unignore)
+  update_ignores(project = project, additional_unignore_files = config_file_name)
   
   # Initialize new renv project w/ snapshot date -------------------------------
   config_date <- config$date

--- a/R/slushy_remove.R
+++ b/R/slushy_remove.R
@@ -28,7 +28,7 @@ slushy_remove <- function(project = NULL, restart = TRUE, keep = "slushy_config.
   }
   
   # remove standalone files
-  files <- c(".renvignore", "renv.lock", "DESCRIPTION", "slushy_config.yml") %>%
+  files <- c(".renvignore", "renv.lock", "DESCRIPTION", "slushy_config.yml", ".Rbuildignore") %>%
     setdiff(keep)
 
   for (f in files){

--- a/R/slushy_trim.R
+++ b/R/slushy_trim.R
@@ -31,7 +31,7 @@
 #'  slushy_trim(config = get_config("slushy_config.yml"))
 #' }
 #' 
-slushy_trim <- function(project = NULL, config = get_config(config_file = "slushy_config.yml")) {
+slushy_trim <- function(project = NULL, config = get_config()) {
   
   if (is.null(project)) {
     project <- proj_root()

--- a/man/slushy_trim.Rd
+++ b/man/slushy_trim.Rd
@@ -4,10 +4,7 @@
 \alias{slushy_trim}
 \title{Trim installed packages}
 \usage{
-slushy_trim(
-  project = NULL,
-  config = get_config(config_file = "slushy_config.yml")
-)
+slushy_trim(project = NULL, config = get_config())
 }
 \arguments{
 \item{project}{The project directory. If NULL, defaults to the nearest parent

--- a/tests/testthat/test-get-config.R
+++ b/tests/testthat/test-get-config.R
@@ -1,0 +1,27 @@
+test_that("get_config attaches the correct file name", {
+  # create a temp config file
+  temp_config_file <- tempfile(fileext = ".yml")
+  
+  # write a simple config contents
+  writeLines("
+  default:
+    config_name: 'my_custom_config'
+    my_custom_config:
+      key1: 'value1'
+      key2: 'value2'
+  ", temp_config_file)
+  
+  # call the get_config
+  result <- get_config(temp_config_file)
+  
+  # check if the correct config list is returned
+  expect_equal(result$key1, 'value1')
+  expect_equal(result$key2, 'value2')
+  
+  # check file name attribute is correctly attached
+  expect_equal(attr(result, "config_file_name"), temp_config_file)
+  
+  # clean up temp file
+  unlink(temp_config_file)
+})
+

--- a/tests/testthat/test-update_ignoreR.R
+++ b/tests/testthat/test-update_ignoreR.R
@@ -1,0 +1,42 @@
+test_that("update_ignores modifies .gitignore correctly", {
+  # create a temp dir
+  temp_dir <- tempdir()
+  
+  # create a temp .gitignore
+  gitignore_path <- file.path(temp_dir, ".gitignore")
+  writeLines(c("existing_file.txt"), gitignore_path)  # initial content
+  
+  # create a temp config file
+  temp_config_file <- tempfile(fileext = ".yml")
+  writeLines("
+  default:
+    config_name: 'my_custom_config'
+    my_custom_config:
+      key1: 'value1'
+      key2: 'value2'
+  ", temp_config_file)
+  
+  # call update_ignores with the temp dir and the config file name
+  slushy:::update_ignores(project = temp_dir, additional_unignore_files = basename(temp_config_file))
+  
+  # read the contents of the .gitignore file
+  updated_gitignore <- readLines(gitignore_path, warn = FALSE)
+  
+  # expected renv_files including the temp config file unignored
+  renv_files <- c("!DESCRIPTION",
+                  "!.Rprofile",
+                  "!.renvignore",
+                  "!renv",
+                  "!renv.lock",
+                  "!*.Rproj",
+                  "existing_file.txt",
+                  paste0("!", basename(temp_config_file)))
+  
+  # check if the updated .gitignore matches the expected renv_files
+  expect_equal(sort(updated_gitignore), sort(renv_files))
+  
+  # clean up temp config file
+  unlink(temp_config_file)
+})
+
+# test when gitignore has contents

--- a/tests/testthat/test-update_ignoreR.R
+++ b/tests/testthat/test-update_ignoreR.R
@@ -4,7 +4,7 @@ test_that("update_ignores modifies .gitignore correctly", {
   
   # create a temp .gitignore
   gitignore_path <- file.path(temp_dir, ".gitignore")
-  writeLines(c("existing_file.txt"), gitignore_path)  # initial content
+  writeLines(c(".Rproj.user", ".Rhistory", ".RData", ".Ruserdata"), gitignore_path)  # initial content
   
   # create a temp config file
   temp_config_file <- tempfile(fileext = ".yml")
@@ -23,20 +23,22 @@ test_that("update_ignores modifies .gitignore correctly", {
   updated_gitignore <- readLines(gitignore_path, warn = FALSE)
   
   # expected renv_files including the temp config file unignored
-  renv_files <- c("!DESCRIPTION",
+  renv_files <- c(".Rproj.user",
+                  ".Rhistory",
+                  ".RData",
+                  ".Ruserdata",
+                  "!DESCRIPTION",
                   "!.Rprofile",
                   "!.renvignore",
                   "!renv",
                   "!renv.lock",
                   "!*.Rproj",
-                  "existing_file.txt",
                   paste0("!", basename(temp_config_file)))
   
   # check if the updated .gitignore matches the expected renv_files
   expect_equal(sort(updated_gitignore), sort(renv_files))
   
-  # clean up temp config file
+  # clean up
   unlink(temp_config_file)
+  unlink(temp_dir)
 })
-
-# test when gitignore has contents


### PR DESCRIPTION
excluding the first 3 commits, addressing #27

**logic of changes made:**
- save name of config file supplied to `get_config()` in `slushy_init()` as an attribute "config_file_name" to `config_list`
- call `config_file_name` from the `config` param in `slushy_init()`
- supply this to the newly added `update_ignores(additional_unignore_files = ...)` param
- within this function, an exclamation mark is prepended to `additional_unignore_files` and then appended to `renv_files`
- add tests for `get_config()` and `update_ignores()`
